### PR TITLE
Added clear and history magics

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,10 @@ improvements:
 - Auto-imports submodules.
 - ``pip``-installable.
 
+To see auto imports from the current session: ``%autoimport -l``
+
+To clear the cache for a symbol with multiple possible imports: ``%autoimport -c SYMBOL``
+
 Installation
 ------------
 
@@ -55,9 +59,11 @@ As usual, install using pip:
    $ pip install ipython-autoimport  # from PyPI
    $ pip install git+https://github.com/anntzer/ipython-autoimport  # from Github
 
-Then, append the output of ``python -mipython_autoimport`` to the
+Then, append the output of ``python -m ipython_autoimport`` to the
 ``ipython_config.py`` file in the directory printed by ``ipython profile
 locate`` (typically ``~/.ipython/profile_default/``).
+
+If you don't have such a file at all, you can use ``ipython profile create``.
 
 Run tests with ``pytest``.
 

--- a/tests/test_autoimport.py
+++ b/tests/test_autoimport.py
@@ -73,6 +73,31 @@ def test_del(ip):
     assert captured.stdout == "ok\n"
 
 
+def test_list(ip):
+    ip.run_cell("os")
+    with IPython.utils.io.capture_output() as captured:
+        ip.run_cell("%autoimport -l")
+    assert (captured.stdout == 
+            "Autoimport: the following autoimports were run:\nimport os\n")
+
+
+def test_no_list(ip):
+    with IPython.utils.io.capture_output() as captured:
+        ip.run_cell("%autoimport -l")
+    assert (captured.stdout == 
+            "Autoimport: no autoimports in this session yet.\n")
+
+
+def test_noclear(ip):
+    with IPython.utils.io.capture_output() as captured:
+        ip.run_cell("%autoimport -c ipython_autoimport_test_noclear")
+    assert (
+        captured.stdout ==
+        "Autoimport: didn't find symbol "
+        "'ipython_autoimport_test_noclear' in autoimport cache.\n"
+    )
+
+
 def test_unload(ip):
     with IPython.utils.io.capture_output() as captured:
         ip.run_cell("%unload_ext ipython_autoimport")


### PR DESCRIPTION
Love this package!

I've added a magic `%autoimport [-c CLEAR] [-l]`.

`-c` is used to clear import cache for a symbol. So if you have multiple imports for `walk` (like from `ast` and `os`), then you can use
`%autoimport -c walk`
and the next import will be what counts in following sessions.

`-l` is used to show all the autoimported symbols in the current session. This is useful when working in a notebook and you want to clean it up for reproducibility.