### PR TITLE
test for prun; fix for prun

### DIFF
--- a/tests/test_autoimport.py
+++ b/tests/test_autoimport.py
@@ -98,6 +98,19 @@ def test_noclear(ip):
     )
 
 
+@pytest.mark.parametrize("magic", ["time", "timeit -n 1 -r 1", "prun"])
+def test_magics(ip, magic):
+    with IPython.utils.io.capture_output() as captured:
+        ip.run_cell(f"{magic} x = 1")
+    assert "error" not in captured.stdout.lower()
+
+
+def test_no_autoimport_in_time(ip):
+    with IPython.utils.io.capture_output() as captured:
+        ip.run_cell(f"%time type(get_ipython().user_ns)")
+    assert "autoimport" not in captured.stdout.lower()
+
+
 def test_unload(ip):
     with IPython.utils.io.capture_output() as captured:
         ip.run_cell("%unload_ext ipython_autoimport")


### PR DESCRIPTION
This commit changes the way autoimport installs and uninstalls itself when the special magics are called, i.e. time, timeit, and prun.

Instead of patching the class methods without a concrete instance of ExecutionMagics, we keep a pointer to the already registered bound methods.

I added 2 tests: one to check that the magics work fine, and another to check that autoimport is not the user namespace when using the time magic. The latter was passing before the registering change, but I thought it's a good idea to have it.