### PR TITLE
Add missing console script entry point

### DIFF
--- a/lib/ipython_autoimport.py
+++ b/lib/ipython_autoimport.py
@@ -278,8 +278,7 @@ def unload_ipython_extension(ipython):
     # Unpatch timing magics.
     ipython.register_magics(_UnpatchedMagics)
 
-
-if __name__ == "__main__":
+def main():
     if os.isatty(sys.stdout.fileno()):
         print("""\
 # Please append the output of this command to the
@@ -289,3 +288,7 @@ if __name__ == "__main__":
     print("""\
 c.InteractiveShellApp.exec_lines.append(
     "try:\\n    %load_ext ipython_autoimport\\nexcept ImportError: pass")""")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,11 @@ setup(
         "version_scheme": "post-release",
         "local_scheme": "node-and-date",
     },
+    entry_points={
+        "console_scripts": [ 
+            "ipython_autoimport=ipython_autoimport:main"
+        ]
+    },
     install_requires=[
         "ipython>=4.1",  # IPython#8985 is needed for tests to pass(?).
         "importlib_metadata; python_version<'3.8'",


### PR DESCRIPTION
This adds the `python -m ipython_autoimport` promised by the README